### PR TITLE
Make 'permalinks_table' parameter optional in service config

### DIFF
--- a/schemas/qwc-permalink-service.json
+++ b/schemas/qwc-permalink-service.json
@@ -54,8 +54,7 @@
         }
       },
       "required": [
-        "db_url",
-        "permalinks_table"
+        "db_url"
       ]
     }
   },


### PR DESCRIPTION
Hi,

I don't think `permalinks_table` should be required in service config as it has default value. Other options have already changed to be optional in the past https://github.com/qwc-services/qwc-permalink-service/commit/2627d12d3506d531b97c6e3bf1cf8c801a41ae31.

Thanks